### PR TITLE
Add CD deployment workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,95 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      build-new-version:
+        description: 'Build now and deploy the app'
+        default: 'true'
+        required: false
+
+jobs:
+  build-and-deploy-app:
+    runs-on: ubuntu-latest
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Create .env file
+        run: |
+          echo "${{ secrets.FIREBASE_ENV_FILE }}" > ./ucrconnect-dashboard/.env
+          echo "NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}" >> ./ucrconnect-dashboard/.env
+
+      - name: Docker meta data for image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKER_USERNAME }}/frontend-app
+          tags: |
+            type=raw,value=${{ env.COMMIT_SHA }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value={{date 'DD/MM/YYYY'}}
+          labels: |
+            org.label-schema.vcs-ref=${{ env.SHORT_SHA }}
+            org.label-schema.vcs-branch=${{ github.head_ref || github.base_ref }}
+            org.label-schema.build-date={{date 'YYYY-MM-DDTHH:mm:ssZ'}}
+            org.label-schema.vcs-url=${{ github.server_url }}/${{ github.repository }}
+
+      - name: Print docker metadata fields
+        run: |
+          echo "Docker metadata tags: ${{ steps.meta.outputs.tags }}"
+
+      - name: Docker login
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ucrconnect-dashboard
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Delete all stoped and unused docker artifacts in production server
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            docker system prune -a -f
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOYMENT_SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            mkdir -p ~/app
+            cd ~/app/ucrconnect-dashboard
+            # Pull the built image and run it
+            docker pull ${{ secrets.DOCKER_USERNAME }}/frontend-app:${{ env.COMMIT_SHA }}
+            docker stop frontend-app || true
+            docker rm frontend-app || true
+            docker run -d --name frontend-app -p 3001:3000 ${{ secrets.DOCKER_USERNAME }}/frontend-app:${{ env.COMMIT_SHA }}
+            # Check the container is up and running, if not then fail workflow
+            if ! docker ps --filter "name=frontend-app" --filter "status=running" --format '{{.Names}}' | grep -w frontend-app ; then
+              echo "Container is not running, exiting..."
+              exit 1
+            fi
+
+

--- a/ucrconnect-dashboard/Dockerfile
+++ b/ucrconnect-dashboard/Dockerfile
@@ -1,0 +1,32 @@
+# Base build image
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy ONLY package files and install dependencies and exclude for now the whole codebase, to get advantage of the caching layers of npm
+COPY package*.json ./
+RUN npm install
+
+# Now copy the rest of the codebase and build the app(we include the .env file in this first stage, which ensures the 'npm run build' command runs succesfully AND 'consume' those credentials)
+COPY . .
+RUN npm run build
+
+# Lightweight production image
+FROM node:18-alpine AS runner
+
+# Set NODE_ENV to production to make next js run efficiently
+ENV NODE_ENV=production
+
+# Set working directory
+WORKDIR /app
+
+# Copy only the necessary files from the builder stage
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+# Expose the port Next.js will run on
+EXPOSE 3001 
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## Type of Change
[x] ci - New workflow for CD
[x] feat - Added Dockerfile for containerization

**This workflow can't be run until it is merged in the main branch**

## Brief Description
Implemented the CD for this web application to be run in the production server in Digital Ocean(which has the public IP address `157.230.224.13`)
We can also trigger manually the deployment workflow
And added a Dockerfile specifically meant for production only

## Changes Made
- No modification to existing files was made
- Only added the Dockerfile and the workflow yml file to the repository

## How to test
The web app is actually running in the production server, but not from this workflow, but a workflow from a forked repository based from this repository, and can be seen running by going to this [link](http://157.230.224.13:3001/analytics), where the backend user app is also running
To test the Dockerfile and run the app in the container, we must first be in the `ucrconnect-dashboard` directory, and then build the image:
```bash
docker build -t frontend-app .
```

Then run the image in a container
```bash
docker run -d --name frontend-app -p 3001:3000 frontend-app
```

## Additional notes

Because the backend app also used the port 3000 and was deployed first, and both apps are running in the same server, this web app will be assigned to port 3001, but this does **not** mean that we should change the code the port this runs on and change it to the port 3001, because Docker is able to map ports from the host machine to the container running, so there is no need to change the code and make this app run in port 3001
