### PR TITLE
fix(ui): remove duplicated title in sidebar

### DIFF
--- a/ucrconnect-dashboard/src/app/components/sidebar.tsx
+++ b/ucrconnect-dashboard/src/app/components/sidebar.tsx
@@ -122,7 +122,7 @@ export default function Sidebar() {
             <div className="flex-1 py-4">
                 <div className="flex justify-between items-center p-4 border-b border-gray-200">
                     <Link href="/dashboard" className="text-blue-950 text-xl" onClick={() => setIsMobileMenuOpen(false)}>
-                        UCRConnect
+                        UCR Connect
                     </Link>
                 </div>
                 <ul className="space-y-1">
@@ -197,11 +197,6 @@ export default function Sidebar() {
                 <div className="md:hidden fixed inset-0 z-20 flex">
                     {/* Menu */}
                     <div className="w-4/5 bg-white h-full shadow-lg z-30">
-                        <div className="flex justify-between items-center p-4 border-b border-gray-200">
-                            <Link href="/" className="text-blue-950 text-xl" onClick={() => setIsMobileMenuOpen(false)}>
-                                UCR Connect
-                            </Link>
-                        </div>
                         {mobileSidebarContent}
                     </div>
 


### PR DESCRIPTION
**Change Type**
[x] fix

**Short Description**
Fixes a UI issue where the Sidebar displayed a duplicated title.

**Changes Made**

    Removed the redundant title element from the Sidebar component.

**Related To**

    N/A

**How to Test**

    Run the app with npm run dev.

    Navigate to any page where the Sidebar is visible.

    Confirm that the title appears only once and no duplicates are shown.

**Additional Notes**

None.