### PR TITLE
Cu 86a7cda1r  iniciar sesion

### DIFF
--- a/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
@@ -6,10 +6,22 @@ export async function POST(request: Request) {
     
     // Validate required fields
     if (!body.auth_id || !body.auth_token || !body.email || !body.full_name) {
+      console.error('Missing required fields:', {
+        has_auth_id: !!body.auth_id,
+        has_auth_token: !!body.auth_token,
+        has_email: !!body.email,
+        has_full_name: !!body.full_name
+      });
       return NextResponse.json(
         { 
           message: 'Invalid request',
-          details: 'Missing required fields'
+          details: 'Missing required fields',
+          missing_fields: {
+            auth_id: !body.auth_id,
+            auth_token: !body.auth_token,
+            email: !body.email,
+            full_name: !body.full_name
+          }
         },
         { status: 400 }
       );
@@ -32,9 +44,13 @@ export async function POST(request: Request) {
     const backendData = await backendResponse.json();
 
     if (!backendResponse.ok) {
-      // Pass through the backend's error response
+      // Pass through the backend's error response with additional context
       return NextResponse.json(
-        backendData,
+        {
+          ...backendData,
+          frontend_context: 'Login attempt failed',
+          timestamp: new Date().toISOString()
+        },
         { status: backendResponse.status }
       );
     }
@@ -58,7 +74,8 @@ export async function POST(request: Request) {
       { 
         message: 'Internal server error', 
         error: error instanceof Error ? error.message : 'Unknown error',
-        details: 'An unexpected error occurred while processing your request'
+        details: 'An unexpected error occurred while processing your request',
+        stack: error instanceof Error ? error.stack : undefined
       },
       { status: 500 }
     );


### PR DESCRIPTION
Tipo de cambio
[x ] test - Nuevas pruebas o ajustes 
[x] chore - Tareas generales o mantenimiento 

Descripción breve
Se agregó un check extra en caso de que el displayName se guarde como valor nulo, debido a que backend rechaza la solicitud si full_name es nulo. 

Cambios realizados
- Se agregó funcionalidad para tomar del email el nombre completo y no enviarlo en la solicitud a backend como un valor nulo.

Relacionado con
- Historia de usuario CU-86a7cda1r --> iniciar-sesion y CU-86a8b14ha --> registrar nuevo usuario

Cómo probarlo
- npm i
- npm run dev
