### PR TITLE
Cu 86a8ath2u enviar notificaciones

### DIFF
--- a/ucrconnect-dashboard/src/app/(dashboard)/notifications/__test__/page.test.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/notifications/__test__/page.test.tsx
@@ -1,20 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import Notifications from '../page';
+import NotificationForm from '@/app/components/notificationForm';
 
 describe('Notifications Component', () => {
     test('renders the Notifications component with correct heading', () => {
         // Render the component
-        render(<Notifications />);
-
-        // Check if the heading with text is in the document
-        const headingElement = screen.getByText(/notifications/i);
-        expect(headingElement).toBeInTheDocument();
-
-        // Additional test to verify it's an h1 element
-        expect(headingElement.tagName).toBe('H1');
-
-        // Verify the className for styling is applied correctly
-        expect(headingElement).toHaveClass('text-gray-800');
+        render(<NotificationForm />);
     });
 });

--- a/ucrconnect-dashboard/src/app/(dashboard)/notifications/__test__/page.test.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/notifications/__test__/page.test.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import NotificationForm from '@/app/components/notificationForm';
+import Notifications from '@/app/(dashboard)/notifications/page';
 
 describe('Notifications Component', () => {
     test('renders the Notifications component with correct heading', () => {
         // Render the component
-        render(<NotificationForm />);
+        render(<Notifications/>);
+
+        expect(screen.getByLabelText(/título/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/descripción/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/tópico/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /enviar notificación/i })).toBeDisabled();
     });
 });

--- a/ucrconnect-dashboard/src/app/(dashboard)/notifications/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/notifications/page.tsx
@@ -3,7 +3,6 @@ import NotificationForm from '@/components/notificationForm';
 export default function Notifications() {
   return (
     <div className="p-6 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-semibold mb-4 text-white">Enviar Notificación</h1>
       <NotificationForm />
     </div>
   );

--- a/ucrconnect-dashboard/src/app/(dashboard)/notifications/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/notifications/page.tsx
@@ -1,7 +1,10 @@
+import NotificationForm from '@/components/notificationForm';
+
 export default function Notifications() {
   return (
-    <div>
-      <h1 className="text-gray-800">Notifications</h1>
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4 text-white">Enviar Notificación</h1>
+      <NotificationForm />
     </div>
   );
 }

--- a/ucrconnect-dashboard/src/app/api/admin/auth/notification/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/notification/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const { title, description, topic } = body;
+
+  if (!title || !description || !topic) {
+    return NextResponse.json({ message: "Faltan campos obligatorios" }, { status: 400 });
+  }
+
+  await new Promise((res) => setTimeout(res, 1000));
+
+  console.log("Mock: Notificación enviada", body);
+
+  return NextResponse.json({ message: "Notificación enviada correctamente (mock)" });
+}

--- a/ucrconnect-dashboard/src/app/api/admin/auth/notification/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/notification/route.ts
@@ -10,7 +10,5 @@ export async function POST(req: Request) {
 
   await new Promise((res) => setTimeout(res, 1000));
 
-  console.log("Mock: Notificación enviada", body);
-
   return NextResponse.json({ message: "Notificación enviada correctamente (mock)" });
 }

--- a/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
+++ b/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import NotificationForm from '@/components/notificationForm';
 import "@testing-library/jest-dom";
 
@@ -131,7 +131,9 @@ describe('NotificationForm', () => {
       expect(screen.getByText(/notificación enviada correctamente/i)).toBeInTheDocument();
     });
 
-    jest.advanceTimersByTime(3000);
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
     await waitFor(() =>
       expect(screen.queryByText(/notificación enviada correctamente/i)).not.toBeInTheDocument()
     );
@@ -173,7 +175,6 @@ describe('NotificationForm', () => {
 
     const form = submitButton.closest('form');
     fireEvent.submit(form!);
-    screen.debug();
 
     await waitFor(() => {
       expect(screen.getByText(/Formulario inválido: completa los campos requeridos./i)).toBeInTheDocument();

--- a/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
+++ b/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
@@ -12,7 +12,8 @@ afterEach(() => {
 });
 
 describe('NotificationForm', () => {
-  it('renders form fields', () => {
+
+  it('renders base component', () => {
     render(<NotificationForm />);
 
     expect(screen.getByLabelText(/título/i)).toBeInTheDocument();
@@ -33,8 +34,62 @@ describe('NotificationForm', () => {
     await waitFor(() => {
       expect(screen.getByText(/al menos 5 caracteres/i)).toBeInTheDocument();
       expect(screen.getByText(/al menos 10 caracteres/i)).toBeInTheDocument();
+      expect(titleInput).toHaveClass('border-red-500');
+      expect(descriptionInput).toHaveClass('border-red-500');
     });
   });
+
+  it('shows validation errors on invalid input', async () => {
+    render(<NotificationForm />);
+
+    fireEvent.change(screen.getByLabelText(/título/i), {
+      target: { value: '123' },
+    });
+    fireEvent.change(screen.getByLabelText(/descripción/i), {
+      target: { value: '123' },
+    });
+
+    fireEvent.blur(screen.getByLabelText(/título/i));
+    fireEvent.blur(screen.getByLabelText(/descripción/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/al menos 5 caracteres/i)).toBeInTheDocument();
+      expect(screen.getByText(/al menos 10 caracteres/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation errors on long input', async () => {
+    render(<NotificationForm />);
+
+    fireEvent.change(screen.getByLabelText(/título/i), {
+      target: { value: 'a'.repeat(101) },
+    });
+    fireEvent.change(screen.getByLabelText(/descripción/i), {
+      target: { value: 'a'.repeat(1001) },
+    });
+
+    fireEvent.blur(screen.getByLabelText(/título/i));
+    fireEvent.blur(screen.getByLabelText(/descripción/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no debe superar los 100 caracteres/i)).toBeInTheDocument();
+      expect(screen.getByText(/no debe superar los 1000 caracteres/i)).toBeInTheDocument();
+    });
+  });
+
+  test('permite seleccionar un tópico en el menú desplegable', () => {
+    render(<NotificationForm />);
+
+    const select = screen.getByLabelText(/tópico/i);
+
+    expect(select).toHaveValue('all-users');
+
+    fireEvent.change(select, { target: { value: 'all-users' } });
+    fireEvent.blur(select);
+
+    expect(select).toHaveValue('all-users');
+  });
+
 
   it('enables submit button when form is valid', async () => {
     render(<NotificationForm />);
@@ -46,6 +101,9 @@ describe('NotificationForm', () => {
       target: { value: 'Esta es una descripción válida.' },
     });
 
+    fireEvent.blur(screen.getByLabelText(/título/i));
+    fireEvent.blur(screen.getByLabelText(/descripción/i));
+
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /enviar notificación/i })).toBeEnabled();
     });
@@ -53,7 +111,7 @@ describe('NotificationForm', () => {
 
   it('submits form and shows success message', async () => {
     jest.mocked(global.fetch).mockResolvedValueOnce({ ok: true } as Response);
-
+    jest.useFakeTimers()
     render(<NotificationForm />);
 
     fireEvent.change(screen.getByLabelText(/título/i), {
@@ -63,12 +121,22 @@ describe('NotificationForm', () => {
       target: { value: 'Descripción suficientemente larga para pasar' },
     });
 
+    fireEvent.blur(screen.getByLabelText(/título/i));
+    fireEvent.blur(screen.getByLabelText(/descripción/i));
+
     const button = screen.getByRole('button', { name: /enviar notificación/i });
     fireEvent.click(button);
 
     await waitFor(() => {
       expect(screen.getByText(/notificación enviada correctamente/i)).toBeInTheDocument();
     });
+
+    jest.advanceTimersByTime(3000);
+    await waitFor(() =>
+      expect(screen.queryByText(/notificación enviada correctamente/i)).not.toBeInTheDocument()
+    );
+
+    jest.useRealTimers();
   });
 
   it('shows error message if request fails', async () => {
@@ -90,4 +158,49 @@ describe('NotificationForm', () => {
       expect(screen.getByText(/error al enviar notificación/i)).toBeInTheDocument();
     });
   });
+
+  it('shows error message on invalid form submission', async () => {
+    render(<NotificationForm />);
+
+    const titleInput = screen.getByLabelText(/título/i);
+    const descriptionInput = screen.getByLabelText(/descripción/i);
+    const submitButton = screen.getByRole('button', { name: /enviar notificación/i });
+
+    fireEvent.change(titleInput, { target: { value: '123' } });
+    fireEvent.change(descriptionInput, { target: { value: '' } });
+    fireEvent.blur(titleInput);
+    fireEvent.blur(descriptionInput);
+
+    const form = submitButton.closest('form');
+    fireEvent.submit(form!);
+    screen.debug();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Formulario inválido: completa los campos requeridos./i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message on unexpected error', async () => {
+    global.fetch = jest.fn(() => {
+      return Promise.reject('Error plano');
+    }) as jest.Mock;
+
+    render(<NotificationForm />);
+
+    const titleInput = screen.getByLabelText(/título/i);
+    const descriptionInput = screen.getByLabelText(/descripción/i);
+    const submitButton = screen.getByRole('button', { name: /enviar notificación/i });
+
+    fireEvent.change(titleInput, { target: { value: 'Título válido' } });
+    fireEvent.change(descriptionInput, { target: { value: 'Descripción suficientemente larga para pasar' } });
+    fireEvent.blur(titleInput);
+    fireEvent.blur(descriptionInput);
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() =>
+      expect(screen.getByText(/ocurrió un error inesperado/i)).toBeInTheDocument()
+    );
+  });
+
 });

--- a/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
+++ b/ucrconnect-dashboard/src/app/components/__tests__/notificationForm.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import NotificationForm from '@/components/notificationForm';
+import "@testing-library/jest-dom";
+
+// Mock fetch globally
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('NotificationForm', () => {
+  it('renders form fields', () => {
+    render(<NotificationForm />);
+
+    expect(screen.getByLabelText(/título/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/descripción/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/tópico/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /enviar notificación/i })).toBeDisabled();
+  });
+
+  it('shows validation errors on blur', async () => {
+    render(<NotificationForm />);
+
+    const titleInput = screen.getByLabelText(/título/i);
+    const descriptionInput = screen.getByLabelText(/descripción/i);
+
+    fireEvent.blur(titleInput);
+    fireEvent.blur(descriptionInput);
+
+    await waitFor(() => {
+      expect(screen.getByText(/al menos 5 caracteres/i)).toBeInTheDocument();
+      expect(screen.getByText(/al menos 10 caracteres/i)).toBeInTheDocument();
+    });
+  });
+
+  it('enables submit button when form is valid', async () => {
+    render(<NotificationForm />);
+
+    fireEvent.change(screen.getByLabelText(/título/i), {
+      target: { value: 'Notificación válida' },
+    });
+    fireEvent.change(screen.getByLabelText(/descripción/i), {
+      target: { value: 'Esta es una descripción válida.' },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /enviar notificación/i })).toBeEnabled();
+    });
+  });
+
+  it('submits form and shows success message', async () => {
+    jest.mocked(global.fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+    render(<NotificationForm />);
+
+    fireEvent.change(screen.getByLabelText(/título/i), {
+      target: { value: 'Título válido' },
+    });
+    fireEvent.change(screen.getByLabelText(/descripción/i), {
+      target: { value: 'Descripción suficientemente larga para pasar' },
+    });
+
+    const button = screen.getByRole('button', { name: /enviar notificación/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText(/notificación enviada correctamente/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message if request fails', async () => {
+    jest.mocked(global.fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+    render(<NotificationForm />);
+
+    fireEvent.change(screen.getByLabelText(/título/i), {
+      target: { value: 'Título válido' },
+    });
+    fireEvent.change(screen.getByLabelText(/descripción/i), {
+      target: { value: 'Descripción suficientemente larga para pasar' },
+    });
+
+    const button = screen.getByRole('button', { name: /enviar notificación/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText(/error al enviar notificación/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/ucrconnect-dashboard/src/app/components/notificationForm.tsx
+++ b/ucrconnect-dashboard/src/app/components/notificationForm.tsx
@@ -94,8 +94,9 @@ export default function NotificationForm() {
             <h3 className="text-2xl font-bold text-center text-gray-800 mb-10">Enviar Notificación</h3>
             <form onSubmit={handleSubmit} className="flex flex-col gap-4 text-gray-800">
                 <div>
-                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Título <span className="text-red-500">*</span></label>
+                    <label htmlFor="title" className="block text-sm font-semibold text-[#249dd8] mb-1">Título <span className="text-red-500">*</span></label>
                     <input
+                        id="title"
                         type="text"
                         value={title}
                         onChange={(e) => setTitle(e.target.value)}
@@ -109,8 +110,9 @@ export default function NotificationForm() {
                 </div>
 
                 <div>
-                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Descripción <span className="text-red-500">*</span></label>
+                    <label htmlFor="description" className="block text-sm font-semibold text-[#249dd8] mb-1">Descripción <span className="text-red-500">*</span></label>
                     <textarea
+                        id="description"
                         value={description}
                         onChange={(e) => setDescription(e.target.value)}
                         onBlur={() => setTouched((prev) => ({ ...prev, description: true }))}
@@ -124,8 +126,9 @@ export default function NotificationForm() {
                 </div>
 
                 <div>
-                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Tópico <span className="text-red-500">*</span></label>
+                    <label htmlFor="topic" className="block text-sm font-semibold text-[#249dd8] mb-1">Tópico <span className="text-red-500">*</span></label>
                     <select
+                        id="topic"
                         value={topic}
                         onChange={(e) => setTopic(e.target.value)}
                         className="mt-1 w-full block px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"

--- a/ucrconnect-dashboard/src/app/components/notificationForm.tsx
+++ b/ucrconnect-dashboard/src/app/components/notificationForm.tsx
@@ -78,8 +78,12 @@ export default function NotificationForm() {
             setTimeout(() => {
                 setSuccessMessage("");
             }, 3000);
-        } catch (err: any) {
-            setErrorMessage(err.message || "Hubo un error al enviar la notificación.");
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                setErrorMessage(error.message);
+            } else {
+                setErrorMessage("Ocurrió un error inesperado.");
+            }
         } finally {
             setLoading(false);
         }

--- a/ucrconnect-dashboard/src/app/components/notificationForm.tsx
+++ b/ucrconnect-dashboard/src/app/components/notificationForm.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+
+export default function NotificationForm() {
+    const [title, setTitle] = useState("");
+    const [description, setDescription] = useState("");
+    const [topic, setTopic] = useState("all-users");
+    const [loading, setLoading] = useState(false);
+    const [successMessage, setSuccessMessage] = useState("");
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setSuccessMessage("");
+        setErrorMessage("");
+
+        if (!title || !description) {
+            setErrorMessage("El título y descripción son obligatorios.");
+            return;
+        }
+
+        setLoading(true);
+
+        try {
+            const res = await fetch("/api/admin/auth/notification", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({ title, description, topic }),
+            });
+
+            if (!res.ok) throw new Error("Error al enviar notificación");
+
+            setSuccessMessage("Notificación enviada correctamente.");
+            setTitle("");
+            setDescription("");
+        } catch (err) {
+            console.error(err);
+            setErrorMessage("Hubo un error al enviar la notificación.");
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="max-w-4xl mx-auto mt-10 bg-white shadow-xl rounded-2xl p-10">
+            <h3 className="text-2xl font-bold text-center text-gray-800 mb-10">Enviar Notificación</h3>
+            <form onSubmit={handleSubmit} className="flex flex-col gap-4 text-gray-800">
+                <div>
+                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Título <span className="text-red-500">*</span></label>
+                    <input
+                        type="text"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        required
+                        className="mt-1 w-full block px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Descripción <span className="text-red-500">*</span></label>
+                    <textarea
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        required
+                        rows={4}
+                        className="mt-1 w-full block px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-semibold text-[#249dd8] mb-1">Tópico <span className="text-red-500">*</span></label>
+                    <select
+                        value={topic}
+                        onChange={(e) => setTopic(e.target.value)}
+                        className="mt-1 w-full block px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                    >
+                        <option value="all-users">Todos los usuarios</option>
+                        {/* Add more options on the future */}
+                    </select>
+                </div>
+
+                <div className="flex justify-center">
+                    <button
+                        type="submit"
+                        disabled={loading}
+                        className="w-auto py-3 px-10 rounded-full shadow text-white bg-[#249dd8] cursor-pointer hover:bg-[#1b87b9] disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    >
+                        {loading ? "Enviando..." : "Enviar Notificación"}
+                    </button>
+                </div>
+
+                {successMessage && <p className="text-green-600 text-sm mt-2 text-center">{successMessage}</p>}
+                {errorMessage && <p className="text-red-500 text-sm mt-2 text-center">{errorMessage}</p>}
+
+                <div className="text-xs text-gray-500 mt-2">
+                    <p><span className="text-red-500">*</span> Campos obligatorios.</p>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/ucrconnect-dashboard/src/app/components/notificationForm.tsx
+++ b/ucrconnect-dashboard/src/app/components/notificationForm.tsx
@@ -51,14 +51,14 @@ export default function NotificationForm() {
             title: true,
             description: true,
         });
-
-        if (!isFormValid) {
-            throw new Error("Formulario inválido: completa los campos requeridos.");
-        }
-
+        
         setLoading(true);
-
+        
         try {
+            if (!isFormValid) {
+                throw new Error("Formulario inválido: completa los campos requeridos.");
+            }
+            
             const res = await fetch("/api/admin/auth/notification", {
                 method: "POST",
                 headers: {


### PR DESCRIPTION
## Change Type  
- [x] feat - New feature  
- [x] test - New or updated tests  

## Short Description  
Introduced the `/notifications` path to send push notifications to all users. Note: API response is currently mocked.

## Changes Made  
- Created `/notifications` route that uses the notification form component.
- Created a new notificationForm component.
- Added visual design and feedback related with the UCR theme.  
- Added validations for each form field and related feedback messages.  
- Added test coverage for the notificationForm component and notification page.

## Related To  
- CU-86a8ath2u_Enviar-notificaciones

## How to Test

Run the Application Locally. To start the development server and view the application in your browser, run the following command:

`npm run dev`

This will compile the project and host it locally, typically at http://localhost:3000/. Go to "Notificaciones" through the navbar or go to `http://localhost:3000/notifications` and test all its functionalities.

Run the Test Suite. To execute all unit tests and validate that the components behave as expected, run:

`npm test`

This will trigger Jest along with React Testing Library to perform automated tests on key components like Sidebar and Header. Test output will be shown in the terminal, indicating which tests passed or failed and coverage.

# Additional Notes

Make sure you have the variables correctly defined in the .env file. (Download it from "evidencias", must be named ".env.local", and make sure to place it in the project root.)

Make sure to run npm install to install all necessary packages before running or testing the app.

**Important: API responses are currently mocked, and the integration with the backend endpoints will be implemented at a later stage.**