### PR TITLE
Cu 86a7ka6bj registrar nuevo usuario

### DIFF
--- a/ucrconnect-dashboard/src/app/(auth)/login/page.tsx
+++ b/ucrconnect-dashboard/src/app/(auth)/login/page.tsx
@@ -64,12 +64,15 @@ function LoginContent() {
         }),
       });
 
+      const data = await response.json();
+
       if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Failed to authenticate with backend');
+        throw new Error(data.message || 'Failed to authenticate with backend');
       }
 
-      const { access_token } = await response.json();
+      if (data.access_token) {
+        sessionStorage.setItem('access_token', data.access_token);
+      }
 
       window.location.href = '/';
     } catch (error) {

--- a/ucrconnect-dashboard/src/app/(auth)/login/page.tsx
+++ b/ucrconnect-dashboard/src/app/(auth)/login/page.tsx
@@ -77,14 +77,6 @@ function LoginContent() {
         }),
       });
 
-      // const data = await response.json();
-
-      // if (!response.ok) {
-      //   throw new Error(data.message || 'Failed to authenticate with backend');
-      // }
-
-      // if (data.access_token) {
-      //   sessionStorage.setItem('access_token', data.access_token);
       const responseData = await response.json();
 
       if (!response.ok) {

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/__tests__/registerUser.test.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/__tests__/registerUser.test.tsx
@@ -28,10 +28,11 @@ global.fetch = jest.fn();
 describe('RegisterUser Component', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        render(<RegisterUser />);
     });
 
     test('renders the form with all fields and submit button', () => {
+        render(<RegisterUser />);
+
         expect(screen.getByLabelText(/Nombre/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/Correo electrónico/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/^Contraseña\b/i)).toBeInTheDocument();
@@ -40,6 +41,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('shows validation error for empty required fields on blur', async () => {
+        render(<RegisterUser />);
+
         const nameInput = screen.getByLabelText(/Nombre/i);
         const emailInput = screen.getByLabelText(/Correo electrónico/i);
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
@@ -57,6 +60,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates name format correctly', async () => {
+        render(<RegisterUser />);
+
         const nameInput = screen.getByLabelText(/Nombre/i);
 
         fireEvent.change(nameInput, { target: { value: 'invalid-name1' } });
@@ -66,6 +71,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates name lenght correctly', async () => {
+        render(<RegisterUser />);
+
         const nameInput = screen.getByLabelText(/Nombre/i);
 
         fireEvent.change(nameInput, { target: { value: 'x' } });
@@ -80,6 +87,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates email format correctly', async () => {
+        render(<RegisterUser />);
+
         const emailInput = screen.getByLabelText(/Correo electrónico/i);
 
         fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
@@ -89,6 +98,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates email length correctly', async () => {
+        render(<RegisterUser />);
+
         const emailInput = screen.getByLabelText(/Correo electrónico/i);
 
         const maxEmailLength = 100;
@@ -103,6 +114,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates password length correctly', async () => {
+        render(<RegisterUser />);
+
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
 
         fireEvent.change(passwordInput, { target: { value: 'short' } });
@@ -117,6 +130,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates confirm password matches password', async () => {
+        render(<RegisterUser />);
+
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
         const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
 
@@ -128,6 +143,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('validates confirm password when password changes', async () => {
+        render(<RegisterUser />);
+
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
         const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
 
@@ -142,6 +159,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('toggles password visibility', () => {
+        render(<RegisterUser />);
+
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
         const toggleButton = screen.getByRole('button', { name: /toggle password visibility/i });
 
@@ -155,6 +174,8 @@ describe('RegisterUser Component', () => {
     });
 
     test('toggles confirm password visibility', () => {
+        render(<RegisterUser />);
+
         const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
         const toggleButton = screen.getByRole('button', { name: /toggle confirmPassword visibility/i });
 
@@ -168,6 +189,7 @@ describe('RegisterUser Component', () => {
     });
 
     test('displays success message on successful form submission', async () => {
+        jest.useFakeTimers();
         const mockGetIdToken = jest.fn().mockResolvedValue('fake-token');
         const mockUser = {
             uid: '12345',
@@ -188,6 +210,8 @@ describe('RegisterUser Component', () => {
             ok: true, json: async () => ({})
         });
 
+        render(<RegisterUser />);
+
         const nameInput = screen.getByLabelText(/Nombre/i);
         const emailInput = screen.getByLabelText(/Correo electrónico/i);
         const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
@@ -199,25 +223,30 @@ describe('RegisterUser Component', () => {
         fireEvent.change(passwordInput, { target: { value: '12345678' } });
         fireEvent.change(confirmPasswordInput, { target: { value: '12345678' } });
 
-        fireEvent.blur(nameInput);
-        fireEvent.blur(emailInput);
-        fireEvent.blur(passwordInput);
-        fireEvent.blur(confirmPasswordInput);
-
-        await waitFor(() => {
-            expect(submitButton).toBeEnabled();
-        });
+        expect(submitButton).toBeEnabled();
         fireEvent.click(submitButton);
 
         await waitFor(() => {
             expect(createUserWithEmailAndPassword).toHaveBeenCalled();
             expect(fetch).toHaveBeenCalledWith('/api/admin/auth/register', expect.any(Object));
+            expect(mockSignOut).toHaveBeenCalled();
+            expect(deleteApp).toHaveBeenCalledWith(mockSecondaryApp);
             expect(screen.getByText(/Usuario registrado correctamente./i)).toBeInTheDocument();
         });
 
+        await act(async () => {
+            jest.advanceTimersByTime(3000);
+        });
+        await waitFor(() =>
+            expect(screen.queryByText(/Usuario registrado correctamente./i)).not.toBeInTheDocument()
+        );
+
+        jest.useRealTimers();
     });
 
     test('disables submit button when form is invalid', () => {
+        render(<RegisterUser />);
+
         const nameInput = screen.getByLabelText(/Nombre/i);
         fireEvent.change(nameInput, { target: { value: 'John Doe' } });
         fireEvent.blur(nameInput);
@@ -225,4 +254,141 @@ describe('RegisterUser Component', () => {
         const submitButton = screen.getByRole('button', { name: /Registrar usuario/i });
         expect(submitButton).toBeDisabled();
     });
+
+    test('does not submit form if validation fails', async () => {
+        render(<RegisterUser />);
+
+        const nameInput = screen.getByLabelText(/Nombre/i);
+        const emailInput = screen.getByLabelText(/Correo electrónico/i);
+        const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
+        const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
+        const submitButton = screen.getByRole('button', { name: /Registrar usuario/i });
+
+        fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+        fireEvent.change(emailInput, { target: { value: 'invalid-email' } });
+        fireEvent.change(passwordInput, { target: { value: '12345678' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: '12345678' } });
+
+        const form = submitButton.closest('form');
+        fireEvent.submit(form!);
+
+        await waitFor(() => {
+            expect(createUserWithEmailAndPassword).not.toHaveBeenCalled();
+            expect(screen.getByText(/Formato de correo electrónico inválido./i)).toBeInTheDocument();
+        });
+    });
+
+    test.each([
+        [400, { message: 'Algunos datos no son válidos. Verifica e intenta de nuevo.' }, /Algunos datos no son válidos. Verifica e intenta de nuevo./i],
+        [401, { message: 'No estás autorizado para realizar esta acción.' }, /No estás autorizado para realizar esta acción/i],
+        [409, { message: 'El correo electrónico ya está registrado como administrador.' }, /El correo electrónico ya está registrado como administrador./i],
+        [500, { message: 'Hubo un problema en el servidor. Intenta nuevamente más tarde.' }, /Hubo un problema en el servidor. Intenta nuevamente más tarde./i],
+        [419, { message: 'Error no contemplado.' }, /Error no contemplado./i],
+        [419, {}, /Ocurrió un error inesperado./i],
+    ])('shows error message from API response on failed registration', async (status, bodyMessage, expectedError) => {
+        const mockGetIdToken = jest.fn().mockResolvedValue('fake-token');
+        const mockUser = {
+            uid: '12345',
+            getIdToken: mockGetIdToken,
+        };
+
+        const mockSignOut = jest.fn();
+        const mockSecondaryAuth = { signOut: mockSignOut };
+        const mockSecondaryApp = {};
+
+        (getSecondaryAuth as jest.Mock).mockReturnValue({
+            auth: mockSecondaryAuth,
+            app: mockSecondaryApp,
+        });
+
+        (createUserWithEmailAndPassword as jest.Mock).mockResolvedValue({ user: mockUser });
+
+        (deleteUser as jest.Mock).mockResolvedValue(undefined);
+
+        global.fetch = jest.fn().mockResolvedValueOnce({
+            ok: false,
+            status: status,
+            json: async () => (bodyMessage),
+        });
+
+        render(<RegisterUser />);
+
+        const nameInput = screen.getByLabelText(/Nombre/i);
+        const emailInput = screen.getByLabelText(/Correo electrónico/i);
+        const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
+        const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
+        const submitButton = screen.getByRole('button', { name: /Registrar usuario/i });
+
+        fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+        fireEvent.change(emailInput, { target: { value: 'johndoe@ucr.ac.cr' } });
+        fireEvent.change(passwordInput, { target: { value: '12345678' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: '12345678' } });
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(createUserWithEmailAndPassword).toHaveBeenCalled();
+            expect(fetch).toHaveBeenCalled();
+            expect(deleteUser).toHaveBeenCalledWith(mockUser);
+            expect(screen.getByText(expectedError)).toBeInTheDocument();
+        });
+    });
+
+    test('shows error details when err.details its and array (400)', async () => {
+        const mockGetIdToken = jest.fn().mockResolvedValue('fake-token');
+        const mockUser = { uid: '12345', getIdToken: mockGetIdToken };
+        const mockSignOut = jest.fn();
+        const mockSecondaryAuth = { signOut: mockSignOut };
+
+        (getSecondaryAuth as jest.Mock).mockReturnValue({ auth: mockSecondaryAuth, app: {} });
+        (createUserWithEmailAndPassword as jest.Mock).mockResolvedValue({ user: mockUser });
+
+        const errorDetails = ["Campo 'Nombre' es requerido", "Correo inválido"];
+        const fakeErrorResponse = {
+            ok: false,
+            status: 400,
+            json: async () => ({ details: errorDetails }),
+        };
+
+        (global.fetch as jest.Mock).mockResolvedValue(fakeErrorResponse);
+
+        render(<RegisterUser />);
+        fireEvent.change(screen.getByLabelText(/Nombre/i), { target: { value: 'Nombre' } });
+        fireEvent.change(screen.getByLabelText(/Correo electrónico/i), { target: { value: 'johndoe@ucr.ac.cr' } });
+        fireEvent.change(screen.getByLabelText(/^Contraseña\b/i), { target: { value: '12345678' } });
+        fireEvent.change(screen.getByLabelText(/Confirmar Contraseña/i), { target: { value: '12345678' } });
+
+        fireEvent.click(screen.getByRole('button', { name: /Registrar usuario/i }));
+
+        const expectedMessage = errorDetails.join(" ");
+        expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
+    });
+
+    test.each([
+        ['auth/email-already-in-use', /El correo electrónico ya está en uso./i],
+        ['auth/invalid-email', /El correo electrónico no es válido./i],
+        ['auth/weak-password', /La contraseña es demasiado débil. Debe tener al menos 8 caracteres./i],
+    ])('shows error from err.message when there is a standard error', async (code, expectedMessage) => {
+        (createUserWithEmailAndPassword as jest.Mock).mockRejectedValue({ code });
+
+        render(<RegisterUser />);
+        const nameInput = screen.getByLabelText(/Nombre/i);
+        const emailInput = screen.getByLabelText(/Correo electrónico/i);
+        const passwordInput = screen.getByLabelText(/^Contraseña\b/i);
+        const confirmPasswordInput = screen.getByLabelText(/Confirmar Contraseña/i);
+        const submitButton = screen.getByRole('button', { name: /Registrar usuario/i });
+
+        fireEvent.change(nameInput, { target: { value: 'John Doe' } });
+        fireEvent.change(emailInput, { target: { value: 'johndoe@ucr.ac.cr' } });
+        fireEvent.change(passwordInput, { target: { value: '12345678' } });
+        fireEvent.change(confirmPasswordInput, { target: { value: '12345678' } });
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => {
+            expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+        });
+    });
+
+
 });

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -158,18 +158,6 @@ export default function RegisterUser() {
         return Object.keys(formErrors).length === 0;
     };
 
-    // Check if email is available
-    //TODO: fix this function to use a backend API instead of Firebase, since Firebase has EEP enabled and always returns an empty array for the signInMethods
-    const isEmailAvailable = async (email: string): Promise<boolean> => {
-        try {
-            const methods = await fetchSignInMethodsForEmail(auth, email);
-            return methods.length === 0;
-        } catch (error) {
-            console.error('Error verificando email en Firebase:', error);
-            return false;
-        }
-    };
-
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const { name, value } = e.target;
 
@@ -281,10 +269,20 @@ export default function RegisterUser() {
                 setSuccessMessage("");
             }, 3000);
         } catch (err: any) {
-            console.error('Error al registrar usuario.', err);
+
+            let message = "Ocurrió un error al registrar el usuario.";
+
+            if (err.code === "auth/email-already-in-use") {
+                message = "El correo electrónico ya está en uso.";
+            } else if (err.code === "auth/invalid-email") {
+                message = "El correo electrónico no es válido.";
+            } else if (err.code === "auth/weak-password") {
+                message = "La contraseña es demasiado débil. Debe tener al menos 8 caracteres.";
+            }
+
             setErrors(prev => ({
                 ...prev,
-                form: err.message || "Ocurrió un error al registrar el usuario.",
+                form: message,
             }));
         } finally {
             setIsSubmitting(false);

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -300,7 +300,9 @@ export default function RegisterUser() {
 
             let message = "Ocurrió un error al registrar el usuario.";
 
-            if (err.code === "auth/email-already-in-use") {
+            if (err instanceof Error && err.message) {
+                message = err.message;
+            } else if (err.code === "auth/email-already-in-use") {
                 message = "El correo electrónico ya está en uso.";
             } else if (err.code === "auth/invalid-email") {
                 message = "El correo electrónico no es válido.";

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -273,7 +273,7 @@ export default function RegisterUser() {
 
                     default:
                         // Not cotemplated cases
-                        console.warn("Error inesperado:", err.message || response.statusText);
+                        errorMessage = err.message || "Ocurrió un error inesperado.";
                         break;
                 }
                 throw new Error(errorMessage);

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-import { useEffect } from 'react';
-import { getAuth, fetchSignInMethodsForEmail, createUserWithEmailAndPassword, deleteUser } from 'firebase/auth';
-import { auth, getSecondaryAuth } from '@/lib/firebase';
+import { useState, useEffect } from 'react';
+import { createUserWithEmailAndPassword, deleteUser } from 'firebase/auth';
+import { getSecondaryAuth } from '@/lib/firebase';
 import { deleteApp } from 'firebase/app';
 
 // Form error types
@@ -419,7 +418,7 @@ export default function RegisterUser() {
                                 type="button"
                                 onClick={() => setShowConfirmationPassword(!showConfirmationPassword)}
                                 className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700"
-                                aria-label="toggle password visibility"
+                                aria-label="toggle confirmPassword visibility"
                             >
                                 {showConfirmationPassword ? (
                                     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -290,12 +290,12 @@ export default function RegisterUser() {
     };
 
     return (
-        <div>
-            <h2 className="mt-2 text-gray-600">Registrar nuevo usuario</h2>
-            <div className="mt-10 w-full sm:w-11/12 md:w-3/4 lg:w-1/3">
+        <div className="max-w-4xl mx-auto mt-10 bg-white shadow-xl rounded-2xl p-10">
+            <h3 className="text-2xl font-bold text-center text-gray-800 mb-10">Registrar nuevo usuario administrador</h3>
+            <div>
                 <form onSubmit={handleSubmit} className="flex flex-col gap-4 text-gray-800">
                     <div>
-                        <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                        <label htmlFor="name" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Nombre <span className="text-red-500">*</span>
                         </label>
                         <input
@@ -314,7 +314,7 @@ export default function RegisterUser() {
                     </div>
 
                     <div>
-                        <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                        <label htmlFor="email" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Correo electrónico <span className="text-red-500">*</span>
                         </label>
                         <input
@@ -333,7 +333,7 @@ export default function RegisterUser() {
                     </div>
 
                     <div>
-                        <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                        <label htmlFor="password" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Contraseña <span className="text-red-500">*</span>
                         </label>
                         <input
@@ -352,7 +352,7 @@ export default function RegisterUser() {
                     </div>
 
                     <div>
-                        <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+                        <label htmlFor="confirmPassword" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Confirmar Contraseña <span className="text-red-500">*</span>
                         </label>
                         <input
@@ -373,7 +373,7 @@ export default function RegisterUser() {
                     <div className="flex justify-center">
                         <button
                             type="submit"
-                            className="mt-2 w-auto py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 cursor-pointer hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="w-auto py-3 px-10 rounded-full shadow text-white bg-[#249dd8] cursor-pointer hover:bg-[#1b87b9] disabled:opacity-50 disabled:cursor-not-allowed transition"
                             disabled={!isFormValid() || isSubmitting}
                             title={!isFormValid() ? 'Complete todos los campos correctamente.' : ''}
                         >

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -208,7 +208,7 @@ export default function RegisterUser() {
         const formErrors = validateForm();
         setErrors(formErrors);
 
-        // No errors and Email available
+        // No errors
         if (Object.keys(formErrors).length > 0) {
             return;
         }

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { getAuth, fetchSignInMethodsForEmail, createUserWithEmailAndPassword, deleteUser } from 'firebase/auth';
 import { auth, getSecondaryAuth } from '@/lib/firebase';
 import { deleteApp } from 'firebase/app';
+import { NextRequest, NextResponse } from 'next/server';
 
 // Form error types
 type FormErrors = {
@@ -254,10 +255,11 @@ export default function RegisterUser() {
             const { auth: secondaryAuth, app: secondaryApp } = getSecondaryAuth();
 
             //Get the auth token from session storage
-            const authToken = sessionStorage.getItem('access_token');
-            if (!authToken) {
-                throw new Error("No se pudo obtener el token de autenticación del admin.");
-            }
+            // const authToken = sessionStorage.getItem('access_token');
+
+            // if (!authToken) {
+            //     throw new Error("No se pudo obtener el token de autenticación del admin.");
+            // }
 
             // Create user in Firebase
             const userCredential = await createUserWithEmailAndPassword(
@@ -271,11 +273,10 @@ export default function RegisterUser() {
             const newUserToken = await newUser.getIdToken();
 
             // Send user data to backend api
-            const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/auth/register`, {
+            const response = await fetch(`/api/admin/auth/register`, {
                 method: "POST",
                 headers: {
                     'Content-Type': 'application/json',
-                    Authorization: `Bearer ${authToken}`,
                 },
                 body: JSON.stringify({
                     email: formData.email,

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -40,6 +40,8 @@ export default function RegisterUser() {
     });
     const [successMessage, setSuccessMessage] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmationPassword, setShowConfirmationPassword] = useState(false);
 
     // Configuring Validation
     const validationConfig = {
@@ -254,13 +256,13 @@ export default function RegisterUser() {
                     auth_token: newUserToken,
                 }),
             });
-            
+
             if (!response.ok) {
                 const err = await response.json();
                 await deleteUser(newUser); // Delete the user from Firebase if the backend registration fails
                 throw new Error(err.message || "Error en el registro en el backend.");
             }
-            
+
             // If the backend registration is successful, sign out the new user from Firebase
             await secondaryAuth.signOut();
             await deleteApp(secondaryApp);
@@ -336,16 +338,36 @@ export default function RegisterUser() {
                         <label htmlFor="password" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Contraseña <span className="text-red-500">*</span>
                         </label>
-                        <input
-                            id="password"
-                            name="password"
-                            type="password"
-                            placeholder="Mínimo 8 caracteres"
-                            value={formData.password}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            className={`mt-1 w-full block px-3 py-2 border ${errors.password ? 'border-red-500' : 'border-gray-300'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
-                        />
+                        <div className="relative">
+                            <input
+                                id="password"
+                                name="password"
+                                type={showPassword ? "text" : "password"}
+                                placeholder="Mínimo 8 caracteres"
+                                value={formData.password}
+                                onChange={handleChange}
+                                onBlur={handleBlur}
+                                className={`mt-1 w-full block pr-10 px-3 py-2 border ${errors.password ? 'border-red-500' : 'border-gray-300'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowPassword(!showPassword)}
+                                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                                aria-label="toggle password visibility"
+                            >
+                                {showPassword ? (
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                                        <line x1="1" y1="1" x2="23" y2="23"></line>
+                                    </svg>
+                                ) : (
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                )}
+                            </button>
+                        </div>
                         {errors.password && touched.password && (
                             <p className="text-red-500 text-sm mt-1">{errors.password}</p>
                         )}
@@ -355,16 +377,36 @@ export default function RegisterUser() {
                         <label htmlFor="confirmPassword" className="block text-sm font-semibold text-[#249dd8] mb-1">
                             Confirmar Contraseña <span className="text-red-500">*</span>
                         </label>
-                        <input
-                            id="confirmPassword"
-                            name="confirmPassword"
-                            type="password"
-                            placeholder="Repite tu contraseña"
-                            value={formData.confirmPassword}
-                            onChange={handleChange}
-                            onBlur={handleBlur}
-                            className={`mt-1 w-full block px-3 py-2 border ${errors.confirmPassword ? 'border-red-500' : 'border-gray-300'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
-                        />
+                        <div className="relative">
+                            <input
+                                id="confirmPassword"
+                                name="confirmPassword"
+                                type={showConfirmationPassword ? "text" : "password"}
+                                placeholder="Repite tu contraseña"
+                                value={formData.confirmPassword}
+                                onChange={handleChange}
+                                onBlur={handleBlur}
+                                className={`mt-1 w-full block px-3 py-2 border ${errors.confirmPassword ? 'border-red-500' : 'border-gray-300'} rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setShowConfirmationPassword(!showConfirmationPassword)}
+                                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700"
+                                aria-label="toggle password visibility"
+                            >
+                                {showConfirmationPassword ? (
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                                        <line x1="1" y1="1" x2="23" y2="23"></line>
+                                    </svg>
+                                ) : (
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                )}
+                            </button>
+                        </div>
                         {errors.confirmPassword && touched.confirmPassword && (
                             <p className="text-red-500 text-sm mt-1">{errors.confirmPassword}</p>
                         )}

--- a/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
     }
 
     // If backend response is successful, set the cookie and return success
-    const successResponse = NextResponse.json({ message: 'Login successful' });
+    const successResponse = NextResponse.json({ message: 'Login successful', access_token: backendData.access_token }, { status: 200 });
     
     // Set the access token from backend as HTTP-only cookie
     successResponse.cookies.set('access_token', backendData.access_token, {

--- a/ucrconnect-dashboard/src/app/api/admin/auth/register/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/register/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const token = request.cookies.get('access_token')?.value;
+
+  if (!token) {
+    return NextResponse.json({ message: 'No se pudo obtener el token' }, { status: 401 });
+  }
+
+  const body = await request.json();
+
+  const backendResponse = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/auth/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await backendResponse.json();
+
+  return new NextResponse(JSON.stringify(data), {
+    status: backendResponse.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/ucrconnect-dashboard/src/app/components/header.tsx
+++ b/ucrconnect-dashboard/src/app/components/header.tsx
@@ -140,7 +140,9 @@ export default function Header() {
             if (!response.ok) {
                 console.error('Failed to logout from backend');
             }
-
+            
+            // Clear the access token cookie
+            sessionStorage.removeItem('access_token');
             // Then logout from Firebase
             await signOut(auth);
             

--- a/ucrconnect-dashboard/src/app/components/header.tsx
+++ b/ucrconnect-dashboard/src/app/components/header.tsx
@@ -141,8 +141,6 @@ export default function Header() {
                 console.error('Failed to logout from backend');
             }
             
-            // Clear the access token cookie
-            sessionStorage.removeItem('access_token');
             // Then logout from Firebase
             await signOut(auth);
             

--- a/ucrconnect-dashboard/src/lib/__tests__/firebase.test.ts
+++ b/ucrconnect-dashboard/src/lib/__tests__/firebase.test.ts
@@ -75,4 +75,56 @@ describe('firebase', () => {
     // Verify auth is exported correctly
     expect(auth).toBe(mockAuthObject); // Check if it's the exact mocked object
   });
+
+  it('returns existing secondary app if already initialized', async () => {
+  const mockSecondaryApp = { name: 'SecondaryApp' };
+  const mockGetApps = jest.fn(() => [mockSecondaryApp]);
+  const mockInitializeApp = jest.fn();
+  const mockAuthObject = {};
+  const mockGetAuth = jest.fn(() => mockAuthObject);
+
+  jest.doMock('firebase/app', () => ({
+    getApps: mockGetApps,
+    initializeApp: mockInitializeApp,
+  }));
+
+  jest.doMock('firebase/auth', () => ({
+    getAuth: mockGetAuth,
+  }));
+
+  const firebaseModule = await import('../firebase');
+  const { getSecondaryAuth } = firebaseModule;
+
+  const result = getSecondaryAuth();
+
+  expect(mockInitializeApp).not.toHaveBeenCalled();
+  expect(mockGetAuth).toHaveBeenCalledWith(mockSecondaryApp);
+  expect(result).toEqual({ auth: mockAuthObject, app: mockSecondaryApp });
+});
+
+it('initializes secondary app if not already initialized', async () => {
+  const mockSecondaryApp = { name: 'SecondaryApp' };
+  const mockGetApps = jest.fn(() => []);
+  const mockInitializeApp = jest.fn(() => mockSecondaryApp);
+  const mockAuthObject = {};
+  const mockGetAuth = jest.fn(() => mockAuthObject);
+
+  jest.doMock('firebase/app', () => ({
+    getApps: mockGetApps,
+    initializeApp: mockInitializeApp,
+  }));
+
+  jest.doMock('firebase/auth', () => ({
+    getAuth: mockGetAuth,
+  }));
+
+  const firebaseModule = await import('../firebase');
+  const { getSecondaryAuth } = firebaseModule;
+
+  const result = getSecondaryAuth();
+
+  expect(mockInitializeApp).toHaveBeenCalledWith(expect.any(Object), 'SecondaryApp');
+  expect(mockGetAuth).toHaveBeenCalledWith(mockSecondaryApp);
+  expect(result).toEqual({ auth: mockAuthObject, app: mockSecondaryApp });
+});
 });

--- a/ucrconnect-dashboard/src/lib/firebase.ts
+++ b/ucrconnect-dashboard/src/lib/firebase.ts
@@ -1,5 +1,6 @@
-import { initializeApp, getApps } from 'firebase/app';
+import { initializeApp, getApps} from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import type { FirebaseApp } from 'firebase/app';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -12,5 +13,14 @@ const firebaseConfig = {
 
 const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
 const auth = getAuth(app);
+
+export function getSecondaryAuth(): { auth: ReturnType<typeof getAuth>, app: FirebaseApp } {
+  const SECONDARY_APP_NAME = 'SecondaryApp';
+  const secondaryApp = getApps().find(app => app.name === SECONDARY_APP_NAME)
+    || initializeApp(firebaseConfig, SECONDARY_APP_NAME);
+
+  const secondaryAuth = getAuth(secondaryApp);
+  return { auth: secondaryAuth, app: secondaryApp };
+}
 
 export { auth }; 


### PR DESCRIPTION
## Change Type  
- [x] feat - Completed feature  
- [x] test - New or updated tests  

## Short Description  
Introduced the `/users/register` path to register new administrator users.

## Changes Made  
- Completed `/users/register` route that uses registerForm.
- Added visual design and feedback related with the UCR theme.  
- Improved validations for each form field and related feedback messages.  
- Added test coverage for the registerUser page.

## Related To  
- CU-86a7ka6bj_Registrar-nuevo-usuario

## How to Test

Run the Application Locally. To start the development server and view the application in your browser, run the following command:

`npm run dev`

This will compile the project and host it locally, typically at http://localhost:3000/. Go to "Usuarios" through the navbar and press "Registrar nuevo usuario" or go to `http://localhost:3000/users/register` and test all its functionalities.

Run the Test Suite. To execute all unit tests and validate that the components behave as expected, run:

`npm test`

This will trigger Jest along with React Testing Library to perform automated tests on key components like Sidebar and Header. Test output will be shown in the terminal, indicating which tests passed or failed and coverage.

# Additional Notes

Make sure you have the variables correctly defined in the .env file. (Download it from "evidencias", must be named ".env.local", and make sure to place it in the project root.)

Make sure to run npm install to install all necessary packages before running or testing the app.