### PR TITLE
fix(register): improve error handling for user registration

### DIFF
--- a/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/register/page.tsx
@@ -300,14 +300,14 @@ export default function RegisterUser() {
 
             let message = "Ocurrió un error al registrar el usuario.";
 
-            if (err instanceof Error && err.message) {
-                message = err.message;
-            } else if (err.code === "auth/email-already-in-use") {
+            if (err.code === "auth/email-already-in-use") {
                 message = "El correo electrónico ya está en uso.";
             } else if (err.code === "auth/invalid-email") {
                 message = "El correo electrónico no es válido.";
             } else if (err.code === "auth/weak-password") {
                 message = "La contraseña es demasiado débil. Debe tener al menos 8 caracteres.";
+            } else if (err instanceof Error && err.message) {
+                message = err.message;
             }
 
             setErrors(prev => ({


### PR DESCRIPTION
## Change Type  
- [x] fix - Bug fix

## Short Description  
Fixed error message showing incorrectly

## Changes Made  
- Fixed an error message 

## Related To  
- CU-86a7ka6bj_Registrar-nuevo-usuario

## How to Test
Go to `/users/register` and try to create a user with an already existing user email, the error should be user friendly and not technical like `auth/email-already-in-use`
