### PR TITLE
fix: change to test if the login in deployment works. Set secure to f…

### DIFF
--- a/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/login/route.ts
@@ -61,8 +61,9 @@ export async function POST(request: Request) {
     // Set the access token from backend as HTTP-only cookie
     successResponse.cookies.set('access_token', backendData.access_token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      // secure: process.env.NODE_ENV === 'production',
+      secure: false,
+      sameSite: 'lax',
       path: '/',
       maxAge: 60 * 60 * 24 // 24 hours
     });


### PR DESCRIPTION
Change type
[x] fix

Short description
Test login functionality in deployment by adjusting cookie settings.

Changes made

- Set secure to false to allow cookies over HTTP connections.
- Changed sameSite to 'lax' for more permissive cookie behavior.

Related to

Issue: login 

How to test it

- Go to http://157.230.224.13:3001/login and attempt to log in from the deployed site.
- Verify that the session persists and the user is redirected correctly.