### PR TITLE
fix(recover-password): use environment variable for API endpoint call

### DIFF
--- a/ucrconnect-dashboard/src/app/(auth)/recover_password/page.tsx
+++ b/ucrconnect-dashboard/src/app/(auth)/recover_password/page.tsx
@@ -21,8 +21,7 @@ export default function RecoverPassword() {
     setError(''); 
 
     try {
-      // TODO: Usar endpoint real
-      const response = await fetch('/api/recover-password', {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/recover-password`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
Change type
[x] feat
[x] fix

Short description
Updated recover password API to use a real endpoint instead of a mock response.

Changes made

- Updated API call to recover password to use a real endpoint.

Related to

86a8znx4y - Recuperar Contraseña

How to test it
- Run the app with `npm run dev`.
- Go to `http://localhost:3000/recover_password` or the equivalent in your environment.
- Enter your email and press "Recuperar contraseña". Verify that you receive the email and can change your password through the link provided.
- Try logging in with your new password.

Additionally, run `npm test` and `npm run build` to ensure everything is working as intended.

Notes:
If you don't have an account, you can request one or create it yourself.
To create an account manually, you need to log in with the credentials found in Slack, under the Notas tab in the Web channel.
Then go to `/users/register` and enter your information.
