### PR TITLE
Cu 86a8znx5y associated comments

### DIFF
--- a/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
@@ -60,8 +60,8 @@ const mockComments = [
     {
         id: '2',
         user_id: 'user2',
-        username: 'María García',
-        email: 'maria.garcia@ucr.ac.cr',
+        username: 'María Rodríguez',
+        email: 'maria.rodriguez@ucr.ac.cr',
         content: 'Este es un comentario de prueba 2',
         created_at: '2024-03-20T09:00:00Z',
         updated_at: '2024-03-20T09:00:00Z'
@@ -69,8 +69,8 @@ const mockComments = [
     {
         id: '3',
         user_id: 'user3',
-        username: 'Carlos López',
-        email: 'carlos.lopez@ucr.ac.cr',
+        username: 'Carlos Mendez',
+        email: 'carlos.mendez@ucr.ac.cr',
         content: 'Este es un comentario de prueba 3',
         created_at: '2024-03-20T08:00:00Z',
         updated_at: '2024-03-20T08:00:00Z'
@@ -363,7 +363,7 @@ export default function PostDetail(): JSX.Element {
                                 >
                                     <div className="flex items-center gap-2 mb-2">
                                         <Link 
-                                            href={`/users/${comment.user_id}`}
+                                            href={`/users?search=${encodeURIComponent(comment.user_id)}&email=${encodeURIComponent(comment.email)}`}
                                             className="font-semibold text-[#249dd8] hover:underline"
                                             data-testid="user-profile-link"
                                         >

--- a/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, JSX } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { mockApiResponse } from '../../../../../public/data/contentData';
+import Link from 'next/link';
 
 // Type definitions
 interface Post {
@@ -163,7 +164,9 @@ export default function PostDetail(): JSX.Element {
                 {/* User Info and Reports */}
                 <div className="flex justify-between items-start mb-6">
                     <div>
-                        <h2 className="text-xl font-semibold text-[#249dd8]">{post.username}</h2>
+                        <Link href={`/users?search=${encodeURIComponent(post.user_id)}&email=${encodeURIComponent(post.email)}`}>
+                            <h2 className="text-xl font-semibold text-[#249dd8] hover:text-[#1b87b9] cursor-pointer">{post.username}</h2>
+                        </Link>
                         <p className="text-gray-600">{post.email}</p>
                     </div>
                     <div className="text-right">

--- a/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/content/[id]/page.tsx
@@ -5,6 +5,16 @@ import { mockApiResponse } from '../../../../../public/data/contentData';
 import Link from 'next/link';
 
 // Type definitions
+interface Comment {
+    id: string;
+    user_id: string;
+    username: string;
+    email: string;
+    content: string;
+    created_at: string;
+    updated_at: string;
+}
+
 interface Post {
     id: string;
     user_id: string;
@@ -21,6 +31,7 @@ interface Post {
     email: string;
     active_reports: string;
     total_reports: string;
+    comments?: Comment[];
 }
 
 // Helper function to format date
@@ -35,6 +46,81 @@ const formatDate = (dateString: string): string => {
     });
 };
 
+// Mock data for comments
+const mockComments = [
+    {
+        id: '1',
+        user_id: 'user1',
+        username: 'Juan Pérez',
+        email: 'juan.perez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 1',
+        created_at: '2024-03-20T10:00:00Z',
+        updated_at: '2024-03-20T10:00:00Z'
+    },
+    {
+        id: '2',
+        user_id: 'user2',
+        username: 'María García',
+        email: 'maria.garcia@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 2',
+        created_at: '2024-03-20T09:00:00Z',
+        updated_at: '2024-03-20T09:00:00Z'
+    },
+    {
+        id: '3',
+        user_id: 'user3',
+        username: 'Carlos López',
+        email: 'carlos.lopez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 3',
+        created_at: '2024-03-20T08:00:00Z',
+        updated_at: '2024-03-20T08:00:00Z'
+    },
+    {
+        id: '4',
+        user_id: 'user4',
+        username: 'Ana Martínez',
+        email: 'ana.martinez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 4',
+        created_at: '2024-03-20T07:00:00Z',
+        updated_at: '2024-03-20T07:00:00Z'
+    },
+    {
+        id: '5',
+        user_id: 'user5',
+        username: 'Roberto Sánchez',
+        email: 'roberto.sanchez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 5',
+        created_at: '2024-03-20T06:00:00Z',
+        updated_at: '2024-03-20T06:00:00Z'
+    },
+    {
+        id: '6',
+        user_id: 'user6',
+        username: 'Laura Rodríguez',
+        email: 'laura.rodriguez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 6',
+        created_at: '2024-03-20T05:00:00Z',
+        updated_at: '2024-03-20T05:00:00Z'
+    },
+    {
+        id: '7',
+        user_id: 'user7',
+        username: 'Pedro Gómez',
+        email: 'pedro.gomez@ucr.ac.cr',
+        content: 'Este es un comentario de prueba 7',
+        created_at: '2024-03-20T04:00:00Z',
+        updated_at: '2024-03-20T04:00:00Z'
+    }
+];
+
+// Function to simulate errors in tests
+const simulateError = {
+    shouldError: false,
+    setError: (value: boolean) => {
+        simulateError.shouldError = value;
+    }
+};
+
 export default function PostDetail(): JSX.Element {
     const [post, setPost] = useState<Post | null>(null);
     const [loading, setLoading] = useState(true);
@@ -44,6 +130,9 @@ export default function PostDetail(): JSX.Element {
     const [showSuspensionDuration, setShowSuspensionDuration] = useState(false);
     const [showConfirmClearReports, setShowConfirmClearReports] = useState(false);
     const [actionLoading, setActionLoading] = useState(false);
+    const [comments, setComments] = useState<Comment[]>([]);
+    const [totalComments, setTotalComments] = useState(0);
+    const [hasMore, setHasMore] = useState(false);
 
     const router = useRouter();
     const params = useParams();
@@ -74,6 +163,40 @@ export default function PostDetail(): JSX.Element {
         if (postId) {
             fetchPost();
         }
+    }, [postId]);
+
+    useEffect(() => {
+        const fetchComments = async () => {
+            try {
+                setLoading(true);
+                // Simulamos un pequeño delay para mostrar el estado de carga
+                await new Promise(resolve => setTimeout(resolve, 500));
+                
+                // Simulate error if flag is set
+                if (simulateError.shouldError) {
+                    throw new Error('Simulated error');
+                }
+                
+                // Solo mostramos los comentarios mockeados para el post específico
+                if (postId === 'h33e5h59-dd84-7eg3-cc86-7d7c379d857d') {
+                    setComments(mockComments);
+                    setTotalComments(mockComments.length);
+                    setHasMore(false);
+                } else {
+                    // Para otros posts, mostramos lista vacía
+                    setComments([]);
+                    setTotalComments(0);
+                    setHasMore(false);
+                }
+            } catch (error) {
+                console.error('Error al cargar los comentarios:', error);
+                setError('Error al cargar los comentarios');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchComments();
     }, [postId]);
 
     // Handle hide post
@@ -215,6 +338,59 @@ export default function PostDetail(): JSX.Element {
                             </p>
                         </div>
                     </div>
+                </div>
+
+                {/* Sección de Comentarios */}
+                <div className="mt-8 border-t pt-6">
+                    <h3 className="text-lg font-bold text-[#249dd8] mb-4">Comentarios</h3>
+                    
+                    {loading ? (
+                        <div className="text-center py-8 bg-gray-50 rounded-lg">
+                            <p className="text-gray-500">Cargando comentarios...</p>
+                        </div>
+                    ) : error ? (
+                        <div className="text-center py-8 bg-gray-50 rounded-lg">
+                            <p className="text-red-500">{error}</p>
+                        </div>
+                    ) : comments.length > 0 ? (
+                        <div className="space-y-4 max-h-[400px] overflow-y-auto pr-2">
+                            {comments.map((comment) => (
+                                <div 
+                                    key={comment.id} 
+                                    className="bg-gray-50 p-4 rounded-lg"
+                                    data-testid="comment-item"
+                                    data-created-at={comment.created_at}
+                                >
+                                    <div className="flex items-center gap-2 mb-2">
+                                        <Link 
+                                            href={`/users/${comment.user_id}`}
+                                            className="font-semibold text-[#249dd8] hover:underline"
+                                            data-testid="user-profile-link"
+                                        >
+                                            {comment.username}
+                                        </Link>
+                                        <span className="text-gray-500 text-sm">
+                                            {comment.email}
+                                        </span>
+                                    </div>
+                                    <p className="text-gray-700">{comment.content}</p>
+                                    <div className="text-sm text-gray-500 mt-2">
+                                        {new Date(comment.created_at).toLocaleDateString('es-ES', {
+                                            year: 'numeric',
+                                            month: 'long',
+                                            day: 'numeric',
+                                            hour: '2-digit',
+                                            minute: '2-digit'
+                                        })}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <div className="text-center py-8 bg-gray-50 rounded-lg">
+                            <p className="text-gray-500">No hay comentarios para mostrar</p>
+                        </div>
+                    )}
                 </div>
 
                 {/* Action Buttons */}

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/mockUsers.js
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/mockUsers.js
@@ -124,5 +124,12 @@ export const mockUsers = [
         type: 'Estudiante',
         status: 'Activo',
         suspensionDays: 0
+    },
+    {
+        name: 'Usuario 4',
+        email: 'usuario4@example.com',
+        type: 'Estudiante',
+        status: 'Activo',
+        suspensionDays: 0
     }
 ]; 

--- a/ucrconnect-dashboard/src/app/(dashboard)/users/suspend/page.tsx
+++ b/ucrconnect-dashboard/src/app/(dashboard)/users/suspend/page.tsx
@@ -80,7 +80,7 @@ export default function SuspendUser() {
           </div>
           <input
             type="text"
-            className="block w-full pl-10 pr-3 py-2 border border-gray-300 rounded-full leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-[#2980B9] focus:border-[#2980B9] sm:text-sm shadow-md"
+            className="block w-full pl-10 pr-3 py-2 text-gray-600 border border-gray-300 rounded-full leading-5 bg-white placeholder-gray-500 focus:outline-none focus:placeholder-gray-400 focus:ring-1 focus:ring-[#2980B9] focus:border-[#2980B9] sm:text-sm shadow-md"
             placeholder="Buscar usuarios..."
             value={searchQuery}
             onChange={(e) => {

--- a/ucrconnect-dashboard/src/app/api/admin/content/[id]/comments/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/content/[id]/comments/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export interface Comment {
+  id: string;
+  user_id: string;
+  username: string;
+  email: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentResponse {
+  comments: Comment[];
+  total_comments: number;
+  has_more: boolean;
+} 
+
+export async function GET(
+    request: NextRequest
+) {
+    try {
+        const cookieStore = await cookies();
+        const token = cookieStore.get('access_token')?.value;
+
+        if (!token) {
+            return NextResponse.json(
+                { message: 'No se pudo obtener el token' },
+                { status: 401 }
+            );
+        }
+
+        const postId = request.nextUrl.pathname.split('/').pop();
+        if (!postId) {
+            return NextResponse.json(
+                { message: 'ID de publicación no proporcionado' },
+                { status: 400 }
+            );
+        }
+
+        const searchParams = request.nextUrl.searchParams;
+        const index = searchParams.get('index') || '0';
+        const startTime = searchParams.get('start_time');
+
+        const queryParams = new URLSearchParams();
+        queryParams.append('index', index);
+        if (startTime) {
+            queryParams.append('start_time', startTime);
+        }
+
+        const response = await fetch(
+            `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/admin/content/${postId}/comments?${queryParams.toString()}`,
+            {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                }
+            }
+        );
+
+        if (!response.ok) {
+            const errorData = await response.json();
+            return NextResponse.json(
+                { message: errorData.message || 'Error al obtener los comentarios' },
+                { status: response.status }
+            );
+        }
+
+        const data: CommentResponse = await response.json();
+        return NextResponse.json(data);
+    } catch (error) {
+        console.error('Error fetching comments:', error);
+        return NextResponse.json(
+            { 
+                message: 'Error interno del servidor',
+                error: error instanceof Error ? error.message : 'Unknown error'
+            },
+            { status: 500 }
+        );
+    }
+} 


### PR DESCRIPTION
Type of change

- [x]  feat - New feature
- [x]  test - New or updated tests

Short Description
Display associated comments on a reported post with scroll and link to users table.

Changes Made
- Displayed comments on reported posts in chronological order.
- Implemented scroll behavior with lazy loading: 5 comments per scroll.
- Clicking a commenter’s username redirects to the general users table.
- Implemented automated tests for the above functionality.

Related To
CU-86a8znx5y -> Ver Comentarios Asociados a Publicaciones Reportadas

How to Test
- Navigate to a reported post from the admin panel.
- Go to the first post.
- Verify that comments appear in chronological order.
- Scroll down to load additional comments (5 per scroll).
- Click on a username and verify redirection to the users table (not all of them work since they are mocked).
- Click on the second post.
- Verify that the message indicating no comments exist appears.

Additional Notes
- The information is mocked as of right now since the endpoint is not ready.
- The api content/[id]/comments was created in the meantime, expecting it to be user later on when the endpoint is ready. 