### PR TITLE
fix(notificationForm): include admin name in notification payload

### DIFF
--- a/ucrconnect-dashboard/src/app/components/notificationForm.tsx
+++ b/ucrconnect-dashboard/src/app/components/notificationForm.tsx
@@ -60,13 +60,16 @@ export default function NotificationForm() {
             }
             
             // Send the notification to the backend API
-            // name is optional, add if needed using a call to profile API to get the name
+            // name is optional, add if needed using a call to profile API to get the real name
+
+            const adminName = "Administrador"; // Placeholder for admin name
+
             const res = await fetch("/api/admin/auth/notification", {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
                 },
-                body: JSON.stringify({ title, body: description}),
+                body: JSON.stringify({ title, body: description, name: adminName}),
             });
 
             if (!res.ok) throw new Error("Error al enviar notificación");


### PR DESCRIPTION
Change type
[x] fix

Short description
Hotfix to notifications API to send name in payload.

Changes made

- Hotfix to API call to notifications to include name on payload.

Related to

86a8znx4g - Enviar Notificaciones a Usuarios

How to test it
- Run the app with `npm run dev`.
- Go to `http://localhost:3000/notifications` or the equivalent in your environment.
- Send a notification and verify that it shows a success message.

Additionally, run `npm test` and `npm run build` to ensure everything is working as intended.

Notes:
Make sure to have the latest .env file, as notifications use a new port.
To log in, use the credentials found in Slack, under the Notas tab in the Web channel.
