### PR TITLE
fix(recover-password): implement API route proxy for password-recovery

### DIFF
--- a/ucrconnect-dashboard/src/app/(auth)/recover_password/page.tsx
+++ b/ucrconnect-dashboard/src/app/(auth)/recover_password/page.tsx
@@ -21,7 +21,7 @@ export default function RecoverPassword() {
     setError(''); 
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/recover-password`, {
+      const response = await fetch("/api/admin/auth/recoverpassword", {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/ucrconnect-dashboard/src/app/api/admin/auth/recoverpassword/route.ts
+++ b/ucrconnect-dashboard/src/app/api/admin/auth/recoverpassword/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  
+  const body = await request.json();
+
+  const backendResponse = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/recover-password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const data = await backendResponse.json();
+
+  return new NextResponse(JSON.stringify(data), {
+    status: backendResponse.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
Change type
[x] fix

Short description
Hotfix to recover password API to implement a proxy.

Changes made

- Hotfix to recover password API call to make the fetch via proxy.

Related to

Recuperar Contraseña

How to test it
- Run the app with `npm run dev`.
- Go to `http://localhost:3000/recover_password` or the equivalent in your environment.
- Send recovery email and verify that everything works correctly.

Additionally, run `npm test` and `npm run build` to ensure everything is working as intended.

Notes:
Make sure to have the latest .env file, found in Slack in the evidencias channel.
